### PR TITLE
성적 오류 수정

### DIFF
--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Activity/GradeCheckActivity.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Activity/GradeCheckActivity.java
@@ -26,7 +26,10 @@ public class GradeCheckActivity extends AppCompatActivity {
         ArrayList<String> tabNameArray = new ArrayList<>();
         HashMap<String, Boolean> isDuplicatedTabNameMap = new HashMap<>();
 
-        GradeAllList.setGradeAllInfo();
+        if(!GradeAllList.getIsSet())
+        {
+            GradeAllList.setGradeAllInfo();
+        }
 
         for (int i = 0; i < gradeAllArray.size(); i++)
         {

--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Grade/GradeAllList.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Grade/GradeAllList.java
@@ -29,6 +29,12 @@ public class GradeAllList extends Fragment {
     private static ArrayList<String> gradeCountArray = new ArrayList<>(); //학점
     private static ArrayList<String> gradeRateArray = new ArrayList<>();  //성적
 
+    private static boolean isSet = false;
+
+    public static boolean getIsSet() {
+        return isSet;
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState)
     {
@@ -101,14 +107,6 @@ public class GradeAllList extends Fragment {
 
     public static void setGradeAllInfo()
     {
-        yearArray = new ArrayList<>();       //년도 + 학기
-        divisionArray = new ArrayList<>();   //이수구분
-        nameArray = new ArrayList<>();       //이름
-        gradeCountArray = new ArrayList<>(); //학점
-        gradeRateArray = new ArrayList<>();  //성적
-        gradeAllArray=new ArrayList<>(); // 함수 속에 담겨있는 파일들 초기화
-
-
         gradeAllArray = UserInfo.getInstance().getGradeAll();
 
         // 소계 제외
@@ -122,6 +120,8 @@ public class GradeAllList extends Fragment {
             gradeCountArray.add(gradeAllArray.get(i).getGradeCount());
             gradeRateArray.add(gradeAllArray.get(i).getGradeRate());
         }
+
+        isSet = true;
     }
 
     private TextView getTextViewWithSettings()

--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Grade/GradeAllList.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Grade/GradeAllList.java
@@ -101,6 +101,14 @@ public class GradeAllList extends Fragment {
 
     public static void setGradeAllInfo()
     {
+        yearArray = new ArrayList<>();       //년도 + 학기
+        divisionArray = new ArrayList<>();   //이수구분
+        nameArray = new ArrayList<>();       //이름
+        gradeCountArray = new ArrayList<>(); //학점
+        gradeRateArray = new ArrayList<>();  //성적
+        gradeAllArray=new ArrayList<>(); // 함수 속에 담겨있는 파일들 초기화
+
+
         gradeAllArray = UserInfo.getInstance().getGradeAll();
 
         // 소계 제외


### PR DESCRIPTION
성적 조회시 다시 안해도 되는 연산을 계속하는 문제를 고치면서 생긴 오류로 계산을 한 번만 하지 않고 계속 하면서 생긴 오류였습니다.

이를 해결하기 위해 static boolean 변수를 만들어 세팅을 했는지 판단하는 로직을 추가했습니다.