### PR TITLE
아이디 변경 90일 에러 메세지 제대로 못띄우는 오류 해결

### DIFF
--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/API/ApiLogin.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/API/ApiLogin.java
@@ -122,15 +122,22 @@ public class ApiLogin extends AsyncTask<String, String, Boolean> {
                     .build();
 
             Response response = okHttpClient.newCall(loginRequest).execute();
-            
-            if(response.body().string().contains("ERRMSGINFO") || response.header("set-Cookie") == null)
+
+            result = response.body().string();
+
+            if(result.contains("ERRMSGINFO"))
+            {
+                return false;
+            }
+
+            if(response.header("set-Cookie") == null)
             {
                 return null;
             }
 
             result = response.header("set-Cookie").split(";")[0].split("=")[1];
 
-            return !result.contains("ERRMSGINFO");
+            return true;
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## 📚 개요

> 아이디 변경 후 90일이 지나서 아이디 변경하라는 구문이 안뜨고 네트워크 접속 에러 문구가 떠서 해결했습니다.

## 🕐 리뷰 예상 시간

> 3m

## ❗❗ 중요한 변경점(Option)

> response.body().string()에서 string() 함수가 딱 1번만 불려야한다고 해서 1번만 부르게 로직을 수정했습니다
