### PR TITLE
치킨 햄버거 맛집 리스트 못가져오는 오류 해결

### DIFF
--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Taste/TasteHandler.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Taste/TasteHandler.java
@@ -19,7 +19,7 @@ public class TasteHandler {
         idToStringMap.put(R.id.Caffe, "디저트");
         idToStringMap.put(R.id.IlSik, "일식");
         idToStringMap.put(R.id.Asian, "아시안");
-        idToStringMap.put(R.id.FastFood, "패스트푸드");
+        idToStringMap.put(R.id.FastFood, "치킨");
         idToStringMap.put(R.id.JungSik, "중식");
         idToStringMap.put(R.id.Meat, "고기");
         idToStringMap.put(R.id.Alchol, "술집");


### PR DESCRIPTION
## 📚 개요

> 치킨 햄버거 맛집 리스트 못가져오는 오류를 해결했습니다.

## 🕐 리뷰 예상 시간

> 1m

## ❗❗ 중요한 변경점(Option)

> 기존 TasteHandler 에서 value로 들어가있던 값이 엑셀 값과 달라서 생긴 문제였습니다.
