### PR TITLE
전체 성적 없을 때 터지는 오류 수정

### DIFF
--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Activity/MainActivity.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Activity/MainActivity.java
@@ -313,6 +313,11 @@ public class MainActivity extends AppCompatActivity{
                 startActivity(new Intent(this, TastePlaceActivity.class));
                 break;
             case R.id.grade_all_check_button: // home_layout의 "전체 성적 조회" 버튼
+                if(UserInfo.getInstance().getGradeAllLength() == 0)
+                {
+                    Toast.makeText(this, "조회할 성적이 없습니다.", Toast.LENGTH_SHORT).show();
+                    break;
+                }
                 startActivity(new Intent(this, GradeCheckActivity.class));
                 break;
         }

--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Common/Data/UserInfo.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Common/Data/UserInfo.java
@@ -63,6 +63,10 @@ public class UserInfo {
 
             JSONObject responseJson = new JSONObject(gradeAllResponse);
 
+            JSONObject photoJson = responseJson.getJSONObject("dmPhoto");
+
+            setPhotoUrl(photoJson.getString("PHOTO"));
+
             JSONArray gradeAllJson = responseJson.getJSONArray("DS_GRAD");
             setGradeAllLength(gradeAllJson.length());
 
@@ -78,10 +82,6 @@ public class UserInfo {
                         subject.getString("GRD"),
                         subject.getString("DETM_CD")));
             }
-
-            JSONObject photoJson = responseJson.getJSONObject("dmPhoto");
-
-            setPhotoUrl(photoJson.getString("PHOTO"));
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## 📚 개요

> 전체 성적이 없을 때 터지는 오류를 수정했습니다.

## 🕐 리뷰 예상 시간

> 2m

## ❗❗ 중요한 변경점(Option)

> JSON 파싱 때 없는 오브젝트를 참조할 때 catch에 걸렸습니다. 그래서 사진을 먼저 가져오게끔 바꿨고 전체성적이 없을 때에는 액티비티 전환을 하지않게 개정했습니다.
