### PR TITLE
성적 조회에서 타 계정 성적 조회되는 기능 수정됐습니다

### DIFF
--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Common/Data/UserInfo.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Common/Data/UserInfo.java
@@ -61,6 +61,8 @@ public class UserInfo {
         {
             gradeAllArray.clear();
 
+            gradeNowArray.clear();
+
             JSONObject responseJson = new JSONObject(gradeAllResponse);
 
             JSONObject photoJson = responseJson.getJSONObject("dmPhoto");

--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Common/Data/UserInfo.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Common/Data/UserInfo.java
@@ -59,9 +59,7 @@ public class UserInfo {
     {
         try
         {
-            gradeAllArray.clear();
-
-            gradeNowArray.clear();
+            clearGrade();
 
             JSONObject responseJson = new JSONObject(gradeAllResponse);
 
@@ -203,6 +201,12 @@ public class UserInfo {
 
     public ArrayList<Grade> getGradeNow() {
         return gradeNowArray;
+    }
+
+    public void clearGrade()
+    {
+        gradeAllArray.clear();
+        gradeNowArray.clear();
     }
 
 }

--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Common/Data/UserInfo.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Common/Data/UserInfo.java
@@ -203,7 +203,7 @@ public class UserInfo {
         return gradeNowArray;
     }
 
-    public void clearGrade()
+    private void clearGrade()
     {
         gradeAllArray.clear();
         gradeNowArray.clear();


### PR DESCRIPTION
## 📚 개요

> 22년도 1학기 성적이 있는 계정을 로그인 후 성적이 없는 계정에 로그인하면 이전 사용자의 성적이 조회되는 오류가 있었습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

성적 데이터를 얻어와 저장하기 전 저장된 데이터를 삭제해줬습니다

> 리뷰가 비교적 꼼꼼히 이루어져야할 부분이나 파일을 여기다 적어주거나 </br>
> 해당 로직에 직접 코멘트를 달아도 좋습니다
