### PR TITLE
화면 회전 막기 및 다듬기

### DIFF
--- a/KuleumBridge/app/src/main/AndroidManifest.xml
+++ b/KuleumBridge/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
             android:required="false"/>
         <activity
             android:name="com.KonDuckJoa.kuleumbridge.Activity.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -37,16 +38,24 @@
             </intent-filter>
         </activity>
 
-        <activity android:name="com.KonDuckJoa.kuleumbridge.Activity.GradeCheckActivity">
+        <activity
+            android:name="com.KonDuckJoa.kuleumbridge.Activity.GradeCheckActivity"
+            android:screenOrientation="portrait">
         </activity>
 
-        <activity android:name="com.KonDuckJoa.kuleumbridge.Activity.TastePlaceActivity">
+        <activity
+            android:name="com.KonDuckJoa.kuleumbridge.Activity.TastePlaceActivity"
+            android:screenOrientation="portrait">
         </activity>
 
-        <activity android:name="com.KonDuckJoa.kuleumbridge.Taste.TastePlaceList">
+        <activity
+            android:name="com.KonDuckJoa.kuleumbridge.Taste.TastePlaceList"
+            android:screenOrientation="portrait">
         </activity>
 
-        <activity android:name="com.KonDuckJoa.kuleumbridge.Taste.TastePlaceInfo">
+        <activity
+            android:name="com.KonDuckJoa.kuleumbridge.Taste.TastePlaceInfo"
+            android:screenOrientation="portrait">
         </activity>
 
 

--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Activity/GradeCheckActivity.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Activity/GradeCheckActivity.java
@@ -42,10 +42,6 @@ public class GradeCheckActivity extends AppCompatActivity {
 
         TabLayout semesterTabLayout = findViewById(R.id.tabs);
 
-        semesterTabLayout.setBackgroundColor(Color.parseColor("#9FF781"));
-        semesterTabLayout.setSelectedTabIndicatorColor(Color.parseColor("#000000"));
-        semesterTabLayout.setTabTextColors(Color.parseColor("#000000"),Color.parseColor("#000000"));
-
         // 탭 추가 과정
         for (int i = 0; i < tabNameArray.size(); i++)
         {

--- a/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Fragment/HomeFragment.java
+++ b/KuleumBridge/app/src/main/java/com/KonDuckJoa/kuleumbridge/Fragment/HomeFragment.java
@@ -66,9 +66,6 @@ public class HomeFragment extends Fragment
 
             switch(id)
             {
-                case R.id.Drawer_setting:
-                    Toast.makeText(context, ":환경설정 창으로 이동합니다", Toast.LENGTH_SHORT).show();
-                    break;
                 case R.id.Drawer_logout:
                     clearAutoLoginInfo();
                     startActivity(Intent.makeRestartActivityTask(getActivity().getIntent().getComponent()));    // Activity 재시작 구문

--- a/KuleumBridge/app/src/main/res/drawable/rounded_rectangle_view.xml
+++ b/KuleumBridge/app/src/main/res/drawable/rounded_rectangle_view.xml
@@ -10,5 +10,5 @@
         android:topRightRadius="12dp" />
     <stroke
         android:width="5dp"
-        android:color="#808080" />
+        android:color="#9CCAAE" />
 </shape>

--- a/KuleumBridge/app/src/main/res/layout/grade_detail.xml
+++ b/KuleumBridge/app/src/main/res/layout/grade_detail.xml
@@ -13,6 +13,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
+        android:background="#9CCAAE"
+        app:tabIndicatorColor="#AABBDD"
+        app:tabTextColor="@color/black"
         app:tabMode="scrollable"
         tools:ignore="SpeakableTextPresentCheck">
 

--- a/KuleumBridge/app/src/main/res/menu/main_menu.xml
+++ b/KuleumBridge/app/src/main/res/menu/main_menu.xml
@@ -2,9 +2,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/Drawer_setting"
-        android:title="환경설정" />
-    <item
         android:id="@+id/Drawer_logout"
         android:title="로그아웃" />
 


### PR DESCRIPTION
## 📚 개요

> 화면 회전시 앱이 튕기는 현상이 있어서 이를 막기위해 화면을 세로로 고정했습니다.
> 또한 앱을 조금 다듬었습니다.

## 🕐 리뷰 예상 시간

> 3m

## ❗❗ 중요한 변경점(Option)

> 앱에서 사용되는 색상이 조금 변경되었습니다.
